### PR TITLE
Add README for OctoAcme Project Management

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# OctoAcme Project Management Docs
+
+This README serves as the central hub for all OctoAcme project management processes. It provides links to each detailed documentation file and a concise summary of the team’s structured, collaborative approach to project delivery. OctoAcme’s workflows are designed to accelerate onboarding, standardize practices, and convert tacit knowledge into shared, versioned artifacts.
+
+## Overview: Project Management Processes
+
+OctoAcme employs a structured and collaborative approach anchored in clear project initiation, robust planning, and transparent execution. Every project begins with a thorough definition of objectives, deliverables, and success criteria—documented to ensure alignment and consistent onboarding. Planning activities break work into manageable increments, estimate timelines, and assign responsibilities, providing transparency and accountability throughout the lifecycle.
+
+Workflows are reinforced via Kanban boards, daily standups, milestone tracking, and risk registers. Roles include Project Leads, Workstream Owners, QA Coordinators, Engineers, and Stakeholders, each described with explicit responsibilities to ensure cross-functional collaboration. Communication channels include regular documentation updates, status meetings, and escalation paths for rapid issue resolution, maintaining high stakeholder engagement.
+
+Quality assurance practices are deeply integrated from development through release. Formal testing phases, peer reviews, and release gating ensure all deliverables meet high standards. Automated tools are applied for consistency, and post-release retrospectives drive continuous improvement by capturing lessons learned and refining institutional processes. This systematic approach supports OctoAcme’s mission to centralize and standardize knowledge, enable repeatable execution, and reduce single-person dependency risks.
+
+## Docs Navigation
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+---
+
+For guidance on making updates, see the issue templates in `.github/ISSUE_TEMPLATE`.


### PR DESCRIPTION
This README serves as the central hub for all OctoAcme project management processes, providing links to detailed documentation and a summary of the team's approach to project delivery.